### PR TITLE
spring-cloud-k8s-gateway to 1.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.58
 - name: spring-cloud-k8s-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.8
+  version: 1.0.9


### PR DESCRIPTION
Promote spring-cloud-k8s-gateway to version 1.0.9