### PR TITLE
spring-cloud-k8s-minion to 1.0.49

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 1.0.9
 - name: spring-cloud-k8s-minion
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.48
+  version: 1.0.49
 - name: spring-cloud-k8s-boss
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.18


### PR DESCRIPTION
Promote spring-cloud-k8s-minion to version 1.0.49