### PR TITLE
spring-cloud-k8s-gateway to 1.0.11

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: spring-cloud-k8s-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.10
+  version: 1.0.11
 - name: spring-cloud-k8s-minion
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.49


### PR DESCRIPTION
Promote spring-cloud-k8s-gateway to version 1.0.11