### PR TITLE
spring-cloud-k8s-boss to 1.0.22

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,4 +15,4 @@ dependencies:
   version: 1.0.49
 - name: spring-cloud-k8s-boss
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.21
+  version: 1.0.22


### PR DESCRIPTION
Promote spring-cloud-k8s-boss to version 1.0.22