### PR TITLE
spring-cloud-k8s-gateway to 1.0.13

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,3 +13,6 @@ dependencies:
 - name: spring-cloud-k8s-boss
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.23
+- name: spring-cloud-k8s-gateway
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.13


### PR DESCRIPTION
Promote spring-cloud-k8s-gateway to version 1.0.13