### PR TITLE
ttc-infra-gateway to 1.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,3 +7,6 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.build.cd.jenkins-x.io
   version: 2.3.58
+- name: ttc-infra-gateway
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.4


### PR DESCRIPTION
Promote ttc-infra-gateway to version 1.0.4