### PR TITLE
ttc-connectors-processing to 1.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,4 +24,4 @@ dependencies:
   version: 1.0.12
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.2
+  version: 1.0.3


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.3