### PR TITLE
ttc-infra-gateway to 1.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,3 +13,6 @@ dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.11.0
+- name: ttc-infra-gateway
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.1


### PR DESCRIPTION
Promote ttc-infra-gateway to version 1.0.1