### PR TITLE
ttc-connectors-dummytwitter to 1.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: ttc-infra-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.2
+- name: ttc-connectors-dummytwitter
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.9


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.9