### PR TITLE
ttc-connectors-ranking to 1.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -22,3 +22,6 @@ dependencies:
 - name: ttc-rb-english-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.17
+- name: ttc-connectors-ranking
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.4


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.4