### PR TITLE
ttc-connectors-ranking to 1.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,4 +24,4 @@ dependencies:
   version: 1.0.17
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.4
+  version: 1.0.5


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.5