### PR TITLE
ttc-connectors-processing to 1.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -27,4 +27,4 @@ dependencies:
   version: 1.0.5
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.4
+  version: 1.0.5


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.5