### PR TITLE
ttc-query-campaign to 1.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,10 +15,10 @@ dependencies:
   version: 1.0.12
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.4
+  version: 1.0.5
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.8.0 
+  version: 0.8.0
 - name: ttc-rb-english-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.18


### PR DESCRIPTION
Promote ttc-query-campaign to version 1.0.5