### PR TITLE
ttc-query-campaign to 1.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   version: 1.0.12
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.8
+  version: 1.0.9
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.8.0


### PR DESCRIPTION
Promote ttc-query-campaign to version 1.0.9