### PR TITLE
ttc-connectors-reward to 1.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -30,4 +30,4 @@ dependencies:
   version: 1.0.5
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.3
+  version: 1.0.4


### PR DESCRIPTION
Promote ttc-connectors-reward to version 1.0.4