### PR TITLE
ttc-connectors-dummytwitter to 1.0.14

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 1.0.3
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.13
+  version: 1.0.14
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.13


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.14