### PR TITLE
ttc-connectors-ranking to 1.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,7 +24,7 @@ dependencies:
   version: 1.0.20
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.5
+  version: 1.0.6
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.5


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.6