### PR TITLE
ttc-connectors-processing to 1.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 1.0.7
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.5
+  version: 1.0.6
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.4


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.6