### PR TITLE
angular-io-quickstart to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -36,4 +36,4 @@ dependencies:
   version: 0.11.0
 - name: angular-io-quickstart
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Promote angular-io-quickstart to version 0.0.2