### PR TITLE
ttc-connectors-reward to 1.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -30,7 +30,7 @@ dependencies:
   version: 1.0.7
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.5
+  version: 1.0.6
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.11.0


### PR DESCRIPTION
Promote ttc-connectors-reward to version 1.0.6