### PR TITLE
ttc-dashboard-ui to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -34,3 +34,6 @@ dependencies:
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.1
+- name: ttc-dashboard-ui
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.6


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.6