### PR TITLE
ttc-connectors-ranking to 1.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 1.0.21
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.7
+  version: 1.0.8
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.7


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.8