### PR TITLE
ttc-dashboard-ui to 0.0.12

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -36,4 +36,4 @@ dependencies:
   version: 1.0.1
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.9
+  version: 0.0.12


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.12