### PR TITLE
ttc-dashboard-ui to 0.0.14

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -33,7 +33,7 @@ dependencies:
   version: 0.11.0
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.13
+  version: 0.0.14
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.10


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.14