### PR TITLE
ttc-dashboard-ui to 0.0.21

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -30,7 +30,7 @@ dependencies:
   version: 1.0.6
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.15
+  version: 0.0.21
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.13


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.21