### PR TITLE
ttc-connectors-reward to 1.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 1.0.7
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.8
+  version: 1.0.9
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.23


### PR DESCRIPTION
Promote ttc-connectors-reward to version 1.0.9