### PR TITLE
ttc-connectors-processing to 1.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,7 +24,7 @@ dependencies:
   version: 1.0.10
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.7
+  version: 1.0.8
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.9


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.8