### PR TITLE
ttc-dashboard-ui to 0.0.30

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -30,7 +30,7 @@ dependencies:
   version: 1.0.9
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.29
+  version: 0.0.30
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.15


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.30