### PR TITLE
ttc-infra-gateway to 1.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: ttc-infra-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.5
+  version: 1.0.8
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.16


### PR DESCRIPTION
Promote ttc-infra-gateway to version 1.0.8